### PR TITLE
Place header file and shared library into ext directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 default:
-	go build -buildmode=c-shared -o libscatter.so ext/libscatter.go
+	go build -buildmode=c-shared -o ext/libscatter.so ext/libscatter.go
 
 bench:
 	@ruby -Ilib examples/bench.rb


### PR DESCRIPTION
While running the example and trying to execute in IRB I came across an error that files were missing so I moved them manually from the root of the project into the ext directory.
But looking at the above change, I think that this would fix it.
